### PR TITLE
Filter by items in the offer

### DIFF
--- a/code.js
+++ b/code.js
@@ -8,13 +8,13 @@ var bazaarData = {};
 var itemData = {};
 
 // Default values
-var maxOutlay = 1000000;
-var maxOffers = 1;
-var maxQuantity = 0;
-var maxBacklog = 7;
-var includeEnchantments = false;
-var includeSaleToNPCs = true;
-var removeManipulated = false;
+var maxOutlay = localStorage.getItem("maxOutlay") ?? 1000000;
+var maxOffers = localStorage.getItem("maxOffers") ?? 1;
+var maxQuantity = localStorage.getItem("maxQuantity") ?? 0;
+var maxBacklog = localStorage.getItem("maxBacklog") ?? 7;
+var includeEnchantments = localStorage.getItem("includeEnchantments") ?? false;
+var includeSaleToNPCs = localStorage.getItem("includeSaleToNPCs") ?? true;
+var removeManipulated = localStorage.getItem("removeManipulated") ?? false;
 var sortBySalesBacklog = false;
 var sortByProfitPerItem = false;
 var sortByTotalProfit = true;
@@ -485,21 +485,25 @@ document.addEventListener("DOMContentLoaded", function() {
 $('#maxOutlay').val(maxOutlay);
 $('#maxOutlay').keyup(function() {
     maxOutlay = $( this ).val();
+    localStorage.setItem("maxOutlay", maxOutlay);
     updateDisplay();
 });
 $('#maxOffers').val(maxOffers);
 $('#maxOffers').keyup(function() {
     maxOffers = $( this ).val();
+    localStorage.setItem("maxOffers", maxOffers);
     updateDisplay();
 });
 $('#maxQuantity').val(maxQuantity);
 $('#maxQuantity').keyup(function() {
     maxQuantity = $( this ).val();
+    localStorage.setItem("maxQuantity", maxQuantity);
     updateDisplay();
 });
 $('#maxBacklog').val(maxBacklog);
 $('#maxBacklog').keyup(function() {
     maxBacklog = $( this ).val();
+    localStorage.setItem("maxBacklog", maxBacklog);
     updateDisplay();
 });
 $('input.sortBy').on('change', function() {
@@ -510,14 +514,17 @@ $('input.sortBy').on('change', function() {
 });
 $('input#includeEnchantments').on('change', function() {
 	includeEnchantments = $('input#includeEnchantments').is(":checked");
+  localStorage.setItem("includeEnchantments", includeEnchantments);
 	updateDisplay();
 });
 $('input#includeSaleToNPCs').on('change', function() {
 	includeSaleToNPCs = $('input#includeSaleToNPCs').is(":checked");
+  localStorage.setItem("includeSaleToNPCs", includeSaleToNPCs);
 	updateDisplay();
 });
 $('input#removeManipulated').on('change', function() {
 	removeManipulated = $('input#removeManipulated').is(":checked");
+  localStorage.setItem("removeManipulated", removeManipulated);
 	updateDisplay();
 });
 $("input#showOptions").click(function() {

--- a/code.js
+++ b/code.js
@@ -369,11 +369,13 @@ function updateDisplay() {
 	var missingItemExplanation3 = '';
 	var missingItemExplanation4 = '';
 	var missingItemExplanation5 = '';
+	var missingItemExplanation6 = '';
 	var textToHide1 = document.getElementById("button1");
 	var textToHide2 = document.getElementById("button2");
 	var textToHide3 = document.getElementById("button3");
 	var textToHide4 = document.getElementById("button4");
 	var textToHide5 = document.getElementById("button5");
+	var textToHide6 = document.getElementById("button6");
 
 	if (notProfitable.length > 0) {
 		textToHide1.classList.remove("hidden");
@@ -425,12 +427,23 @@ function updateDisplay() {
 		textToHide5.classList.remove("shown");
 		textToHide5.classList.add("hidden");
 	}
+	if (tooMany.length > 0) {
+		textToHide6.classList.remove("hidden");
+		textToHide6.classList.add("shown");
+		tooMany.sort((a, b) => (a.name < b.name) ? -1 : 1);
+		missingItemExplanation6 += tooMany.map(function(o) { return (o.name); }).join(', ');
+	} 
+	else {
+		textToHide6.classList.remove("shown");
+		textToHide6.classList.add("hidden");
+	}
 
 	$('#missingItemExplanation1').html(missingItemExplanation1);
 	$('#missingItemExplanation2').html(missingItemExplanation2);
 	$('#missingItemExplanation3').html(missingItemExplanation3);
 	$('#missingItemExplanation4').html(missingItemExplanation4);
 	$('#missingItemExplanation5').html(missingItemExplanation5);
+	$('#missingItemExplanation6').html(missingItemExplanation6);
 
 }
 

--- a/code.js
+++ b/code.js
@@ -10,6 +10,7 @@ var itemData = {};
 // Default values
 var maxOutlay = 1000000;
 var maxOffers = 1;
+var maxQuantity = 0;
 var maxBacklog = 7;
 var includeEnchantments = false;
 var includeSaleToNPCs = true;
@@ -226,6 +227,7 @@ function updateDisplay() {
 	var notProfitable = [];
 	var notAffordable = [];
 	var notSellable = [];
+  var tooMany = [];
 	var excludedEnchantments = [];
 	var likelyManipulated = [];
 	var cheaperToNPC = [];
@@ -307,9 +309,11 @@ function updateDisplay() {
 				notSellable.push(item);
 			} else if (isLikelyManipulated(highestBuyOrder, lowestSellOffer) && removeManipulated) {
 			    likelyManipulated.push(item);
-			} else {
-				calcData.push(item);
-			}
+			} else if (maxQuantity > 0 && affordableQuantity > maxQuantity) {
+        tooMany.push(item);
+      } else {
+        calcData.push(item);
+      }
 		}
 	}
 
@@ -473,6 +477,11 @@ $('#maxOutlay').keyup(function() {
 $('#maxOffers').val(maxOffers);
 $('#maxOffers').keyup(function() {
     maxOffers = $( this ).val();
+    updateDisplay();
+});
+$('#maxQuantity').val(maxQuantity);
+$('#maxQuantity').keyup(function() {
+    maxQuantity = $( this ).val();
     updateDisplay();
 });
 $('#maxBacklog').val(maxBacklog);

--- a/index.html
+++ b/index.html
@@ -34,6 +34,12 @@
 			</div>
 
 			<div class="tooltipparent">
+				<p>I only want at most <input id="maxQuantity" type="text"> items per offer</p>
+
+				<div class="tooltip">Exclude items with large quantity amounts. Intended to be used for players who do not want to manage high-quantity offer.</div>
+			</div>
+
+			<div class="tooltipparent">
 				<p>Exclude items with a sales backlog of more than <input id="maxBacklog" type="text"> days</p>
 
 				<div class="tooltip">Exclude items with long backlogs: In some cases, certain items may be selling very slowly, leading to a high risk that you will be left with the items, not the profit. This control excludes items from the list that have a backlog of more than a certain number of days.</div>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 			<div class="tooltipparent">
 				<p>I only want at most <input id="maxQuantity" type="text"> items per offer</p>
 
-				<div class="tooltip">Exclude items with large quantity amounts. Intended to be used for players who do not want to manage high-quantity offer.</div>
+				<div class="tooltip">Exclude items with large quantity amounts. Intended to be used for players who do not want to manage high-quantity offer. May not be compatible with multiple offers.</div>
 			</div>
 
 			<div class="tooltipparent">
@@ -125,6 +125,17 @@
 		</button>
 		<div class="content">
 			<div id="missingItemExplanation4"></div>
+		</div>
+	</div>
+
+  <div class="collapsible-container">
+		<button class="collapsible-btn" id="button6">
+			<span class="buttonText"><b>Items excluded from the table because the items per offer is too high.</b></span>
+			<div class="arrow-right"></div>
+			<div class="arrow-down"></div>
+		</button>
+		<div class="content">
+			<div id="missingItemExplanation6"></div>
 		</div>
 	</div>
 

--- a/style.css
+++ b/style.css
@@ -130,6 +130,9 @@ input#maxOutlay {
 input#maxOffers {
   width: 3em;
 }
+input#maxQuantity {
+  width: 5em;
+}
 input#maxBacklog {
   width: 3em;
 }


### PR DESCRIPTION
Built a feature that I wanted to use personally. Thought I'd offer it here in case you want it.
I don't like dealing with bulk bazaar offers so I added this filter to add a max filter to orders.

Example:
Maximum of 64 per offer:
1000x Red sand - Filtered out
3x Super Compactor - Allowed
64x Enchanted Beef - Allowed

Action that may be required if this is to be approved:
There is a bug when using this with multiple offer where it will only limit the quantity of the final offer that I did not feel like fixing.
The orders of class names for the missingItems is out of order.
My writing isn't the best so the titles/tooltips of the feature may need a rewrite.